### PR TITLE
eslint fix: forced to infer types when possible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,7 @@
         "brace-style": ["error", "1tbs"],
         "indent": ["error", 4],
         "quotes": ["error", "double"],
-        "semi": ["error", "always"]
+        "semi": ["error", "always"],
+        "@typescript-eslint/no-inferrable-types": "off"
     }
 }


### PR DESCRIPTION
ESLint does not allow types to be explicitly declared when they could be inferred. See: https://typescript-eslint.io/rules/no-inferrable-types/

VSCode:
![vswarning](https://user-images.githubusercontent.com/31804606/220731137-c3bb52e2-7460-45a1-9369-82523336bd55.png)

GitHub Actions:
![gitfail](https://user-images.githubusercontent.com/31804606/220731291-27a2502f-239d-4768-9198-0b97428cab1f.png)

This is inconsistent with instruction, which directs students to always explicitly state the type.
![tome](https://user-images.githubusercontent.com/31804606/220731880-0c86b631-7557-4e07-9ec0-7b4c99a02d45.PNG)
Many such examples...